### PR TITLE
added missing id parameter to redirect

### DIFF
--- a/breeder/views.py
+++ b/breeder/views.py
@@ -107,7 +107,7 @@ def new_breeder_form(request):
             new_breeder.custom_fields = json.dumps(custom_fields)
             new_breeder.save()
 
-            return redirect('breeder', new_breeder.breeding_prefix)
+            return redirect('breeder', new_breeder.id, new_breeder.breeding_prefix)
         else:
             return render(request, 'new_breeder_form_base.html', {'breeder_form': breeder_form,
                                                                   'custom_fields': custom_fields})


### PR DESCRIPTION
got a 500 error when submitting the create breeder form. it was caused by the redirect missing the parameter for breeder id, so was fixed by adding in the id.