### PR TITLE
template was looking for 'Active' instead of 'Status'

### DIFF
--- a/breeder/templates/edit_breeder_form.html
+++ b/breeder/templates/edit_breeder_form.html
@@ -66,7 +66,7 @@
                                             {% render_field field class="form-control" value=breeder.phone_number2 %}
                                         {% elif field.label == 'Email' %}
                                             {% render_field field class="form-control" value=breeder.email %}
-                                        {% elif field.label == 'Active' %}
+                                        {% elif field.label == 'Status' %}
                                             {% if breeder.active %}
                                                 {{ field|attr:"class:form-control"|attr:"checked: " }}
                                             {% else %}


### PR DESCRIPTION
the label for breeder.active is 'Status', not 'Active'. the template was looking for 'Active' but not finding it, so not showing the checkbox as checked when it should have been.
fixed the edit breeder form to look for the correct label for breeder.active.