### PR TITLE
Zootech date

### DIFF
--- a/pedigree/templates/cert-zootechnical.html
+++ b/pedigree/templates/cert-zootechnical.html
@@ -212,7 +212,7 @@ and caprine species
                 <td class="main-td" colspan="2">
                     <p>
                         9. Date (use format dd/mm/yyyy or ISO 8601) (<small>8</small>) and country of birth of animal
-                        <p class="ans">{{ lvl1.dob }}</p>
+                        <p class="ans">{{ lvl1.dob|date:'d/m/Y' }}</p>
                     </p>
                 </td>
             </tr>


### PR DESCRIPTION
Used slashes instead of dots as the instruction for what format dates should be in (before some were slashes and some were dots, and in the irish pig example document they used slashes).

And I've made the date of birth be in one of the instructed formats (dd/mm/yyyy)