### PR TITLE
file type defect (import was crashing when file type was wrong)

### DIFF
--- a/impex/templates/import.html
+++ b/impex/templates/import.html
@@ -150,12 +150,6 @@
             let reader = new FileReader()
             reader.readAsText(inputFile)
             reader.onload = function() {
-                // the content of the csv file
-                var csvContent = $.csv.toArrays(reader.result)
-                
-                // variable to store whether there were errors
-                var errors = false
-                
                 // validate file type
                 fileType = inputFile.name.substr(inputFile.name.length - 4)
                 if (fileType != '.csv') {
@@ -172,6 +166,12 @@
                     // stop the import
                     return false
                 }
+                
+                // the content of the csv file
+                var csvContent = $.csv.toArrays(reader.result)
+                
+                // variable to store whether there were errors
+                var errors = false
 
                 // find number of lines in file and update modal
                 var totalLines = csvContent.length - 1


### PR DESCRIPTION
moved file type check to the beginning to avoid crashes caused by the file being of the wrong type