### PR TITLE
editted user duplicated defect

### DIFF
--- a/account/views.py
+++ b/account/views.py
@@ -234,19 +234,20 @@ def user_edit(request):
             User.objects.filter(username=request.POST.get('register-form-username'),
                                 email=request.POST.get('register-form-email')).update(first_name=request.POST.get('firstName'),
                                                                                       last_name=request.POST.get('lastName'))
-            new_user = User.objects.get(username=request.POST.get('register-form-username'),
+            existing_user = User.objects.get(username=request.POST.get('register-form-username'),
                                     email=request.POST.get('register-form-email'))
-            # remove user from admins and read only users
-            main_account.admin_users.remove(new_user)
-            main_account.read_only_users.remove(new_user)
+            # remove user from admins and read only users and contributors
+            main_account.admin_users.remove(existing_user)
+            main_account.read_only_users.remove(existing_user)
+            main_account.contributors.remove(existing_user)
 
             # add user to the request group
             if request.POST.get('status') == 'Editor':
-                main_account.admin_users.add(new_user)
-            if request.POST.get('status') == 'Contributor':
-                main_account.contributors.add(new_user)
+                main_account.admin_users.add(existing_user)
+            elif request.POST.get('status') == 'Contributor':
+                main_account.contributors.add(existing_user)
             else:
-                main_account.read_only_users.add(new_user)
+                main_account.read_only_users.add(existing_user)
 
             return HttpResponse(json.dumps({'success': True}))
 


### PR DESCRIPTION
Adam said a customer was asking about this defect so I fixed it

prevented user being duplicated by also removing them from contributors as well as just admin_users and read_only_users, and by having an elif instead of an if to prevent read_only_user being added if user is being changed to an editor.
Also changed the name of the variable in the edit section from new_user to existing_user.