### PR TITLE
unwanted error

### DIFF
--- a/metrics/templates/metrics.html
+++ b/metrics/templates/metrics.html
@@ -607,7 +607,7 @@
                             }
                         } else {
                             // queue item with the given id doesn't exist
-                            errorMsg('failed to update results table');
+                            console.log('failed to update results table');
                         }
                     }
                 });


### PR DESCRIPTION
sometimes in dev when running stud advisor an error message would pop up saying 'failed to update results table'. I think this might have been happening because the results_complete() function that is called every 10 seconds was searching for a stud advisor queue object before it's creation was finished. I changed it so it prints the error to console instead of displaying it to the user so now the user won't see this unwanted error but we can still see it in the console if we need to